### PR TITLE
change to m/s

### DIFF
--- a/ros_ws/src/autonomous/wallfollowing2/script/wallfollowing.py
+++ b/ros_ws/src/autonomous/wallfollowing2/script/wallfollowing.py
@@ -61,6 +61,13 @@ def map(in_lower, in_upper, out_lower, out_upper, value):
     return min(out_upper, max(out_lower, result))
 
 
+def convertRpmToSpeed(rpm):
+    # 1299.224 is the conversion factor from electrical revolutions per minute to m/s 
+    # and is derived from the transmission and the rotational speed of the motor.
+    # More values describing the car properties can be found in car_config.h.
+    return rpm / 1299.224
+
+
 def drive(angle, velocity):
     message = drive_param()
     message.angle = angle
@@ -141,6 +148,8 @@ def follow_walls(left_circle, right_circle, barrier, delta_time):
     last_speed = relative_speed
     speed = map(0, 1, parameters.min_throttle, parameters.max_throttle, relative_speed)  # nopep8
     steering_angle = steering_angle * map(parameters.high_speed_steering_limit_dead_zone, 1, 1, parameters.high_speed_steering_limit, relative_speed)  # nopep8
+    # 20000 are the maximal electrical revolutions per minute. More values describing the car properties can be found in car_config.h.
+    speed = convertRpmToSpeed(speed * 20000)
     drive(steering_angle, speed)
 
     show_line_in_rviz(2, [left_point, right_point],

--- a/ros_ws/src/car_control/include/car_controller.h
+++ b/ros_ws/src/car_control/include/car_controller.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "car_config.h"
 #include "drive_mode.h"
 #include <ros/ros.h>
 
@@ -54,21 +55,33 @@ class CarController
 
     /**
      * @brief takes a speed and angle, converts and forwards them to gazebo/focbox
+     * @param raw_speed the speed in m/s
      */
-    void publishDriveParameters(double raw_speed, double raw_angle);
+    void publishDriveParameters(float raw_speed, float raw_angle);
 
     /**
      * @brief takes speed and publishes it to gazebo/focbox
+     * @param speed the speed in m/s which is converted to rpm and then sent to the focbox
      */
-    void publishSpeed(double speed);
+    void publishSpeed(float speed);
 
     /**
      * @brief takes angle and publishes it to gazebo/focbox
      */
-    void publishAngle(double angle);
+    void publishAngle(float angle);
 
     /**
      * @brief publishes a brake message that stops the car
      */
     void stop();
+
+    /**
+     * @brief converts m/s in revolutions per minute
+     * @param speed speed in m/s
+     * @return revolutions per minute
+     */
+    int convertSpeedToRpm(float speed)
+    {
+        return speed * car_config::TRANSMISSION / car_config::ERPM_TO_SPEED;
+    }
 };

--- a/ros_ws/src/car_control/src/car_controller.cpp
+++ b/ros_ws/src/car_control/src/car_controller.cpp
@@ -1,5 +1,4 @@
 #include "car_controller.h"
-#include "car_config.h"
 
 #include <boost/algorithm/clamp.hpp>
 
@@ -27,26 +26,26 @@ void CarController::driveParametersCallback(const drive_msgs::drive_param::Const
                                  m_drive_param_lock ? 0 : parameters->angle);
 }
 
-void CarController::publishDriveParameters(double relative_speed, double relative_angle)
+void CarController::publishDriveParameters(float speed, float relative_angle)
 {
-    double speed = relative_speed * car_config::MAX_RPM_ELECTRICAL;
-    double angle = (relative_angle * car_config::MAX_SERVO_POSITION + car_config::MAX_SERVO_POSITION) / 2;
+    float rpm = convertSpeedToRpm(speed);
+    float angle = (relative_angle * car_config::MAX_SERVO_POSITION + car_config::MAX_SERVO_POSITION) / 2;
 
-    this->publishSpeed(speed);
+    this->publishSpeed(rpm);
     this->publishAngle(angle);
 
     ROS_DEBUG_STREAM("running: "
                      << " | speed: " << speed << " | angle: " << angle);
 }
 
-void CarController::publishSpeed(double speed)
+void CarController::publishSpeed(float speed)
 {
     std_msgs::Float64 speed_message;
     speed_message.data = speed;
     this->m_speed_publisher.publish(speed_message);
 }
 
-void CarController::publishAngle(double angle)
+void CarController::publishAngle(float angle)
 {
     std_msgs::Float64 angle_message;
     angle_message.data = angle;


### PR DESCRIPTION
Geschwindigkeitswerte sind in der Einheitheit m/s und nicht mehr in einem Wertebereich zwischen -1 und 1. In dem ursprünglichen Wallfollowing Algorithmus wird dieser Wertebereich in m/s umgerechnet, damit der noch normal funktioniert. 
Wenn Manuell gefahren wird, können jetzt maximal ca. 0,33 m/s erreicht werden, da dort keine Umrechnung erfolgt. Hätte ich so gelassen, da keine hohe Geschwindigkeit benötigt wird und das manuelle fahren eher sicherer macht.
Außerdem wird in car_controller float statt double benutzt, da aus der drive_param.msg auch nur float32 rausfallen.