### PR TITLE
Disable ROS Kinetic / Ubuntu 16.04 Build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
         catkin_make run_tests && catkin_test_results
         ./../scripts/travis/check-consistency.sh
   build_kinetic:
+    if: false
     runs-on: ubuntu-16.04
     env:
       ROS_DISTRO: kinetic 


### PR DESCRIPTION
I left the code in should we ever want to reactivate it, it just is commented out for now. 