### PR TITLE
Implement a bare-bones velocity calculation based on IMU values.

### DIFF
--- a/ros_ws/launch/car_wallfollowing.launch
+++ b/ros_ws/launch/car_wallfollowing.launch
@@ -42,6 +42,8 @@
         <rosparam file="$(find hardware)/razor_imu_config.yaml" command="load"/>
     </node>
 
+    <include file="$(find imu_velocity)/launch/car_imu_velocity.launch" />
+
     <node pkg="urg_node" type="urg_node" name="urg_node">
         <param name="ip_address" value="192.168.1.10"/>
     </node>

--- a/ros_ws/launch/gazebo.launch
+++ b/ros_ws/launch/gazebo.launch
@@ -48,6 +48,8 @@
         <arg name="joystick_type" value="$(arg joystick_type)"/>
     </include>
 
+    <include file="$(find imu_velocity)/launch/car_imu_velocity.launch" />
+
     <node pkg="simulation_tools" type="crash_detector" name="crash_detector" output="screen">
     </node>
 </launch>

--- a/ros_ws/src/autonomous/wallfollowing2/script/wallfollowing.py
+++ b/ros_ws/src/autonomous/wallfollowing2/script/wallfollowing.py
@@ -62,7 +62,7 @@ def map(in_lower, in_upper, out_lower, out_upper, value):
 
 
 def convertRpmToSpeed(rpm):
-    # 1299.224 is the conversion factor from electrical revolutions per minute to m/s 
+    # 1299.224 is the conversion factor from electrical revolutions per minute to m/s
     # and is derived from the transmission and the rotational speed of the motor.
     # More values describing the car properties can be found in car_config.h.
     return rpm / 1299.224
@@ -148,7 +148,8 @@ def follow_walls(left_circle, right_circle, barrier, delta_time):
     last_speed = relative_speed
     speed = map(0, 1, parameters.min_throttle, parameters.max_throttle, relative_speed)  # nopep8
     steering_angle = steering_angle * map(parameters.high_speed_steering_limit_dead_zone, 1, 1, parameters.high_speed_steering_limit, relative_speed)  # nopep8
-    # 20000 are the maximal electrical revolutions per minute. More values describing the car properties can be found in car_config.h.
+    # 20000 are the maximal electrical revolutions per minute. More values
+    # describing the car properties can be found in car_config.h.
     speed = convertRpmToSpeed(speed * 20000)
     drive(steering_angle, speed)
 

--- a/ros_ws/src/imu_velocity/CMakeLists.txt
+++ b/ros_ws/src/imu_velocity/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(imu_velocity)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  sensor_msgs
+)
+
+###################################
+## catkin specific configuration ##
+###################################
+
+catkin_package(
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS roscpp sensor_msgs
+)
+
+## Errors and Warnings
+set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wchar-subscripts -Wchkp -Wdouble-promotion -Wformat -Wnonnull -Wmain -Wswitch-bool -Winvalid-memory-model -Wunknown-pragmas -Warray-bounds -Wfloat-equal -Wlogical-op -Wpacked ")
+# -Wpedantic cant be used because of ROS
+
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+
+add_executable(imu_accumulator 
+  src/main.cpp  
+  src/imu_accumulator.cpp
+)
+target_link_libraries(imu_accumulator ${catkin_LIBRARIES})
+add_dependencies(imu_accumulator ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+

--- a/ros_ws/src/imu_velocity/include/imu_accumulator.h
+++ b/ros_ws/src/imu_velocity/include/imu_accumulator.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <ros/ros.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
+#pragma GCC diagnostic pop
+
+#include <sensor_msgs/Imu.h>
+
+constexpr const char* TOPIC_IMU_DATA = "/imu";
+constexpr const char* TOPIC_VELOCITY_OUTPUT = "/racer/velocity";
+constexpr const char* MODEL_BASE_LINK = "base_link";
+
+/**
+ */
+class ImuAccumulator
+{
+    public:
+    ImuAccumulator();
+
+    private:
+    ros::NodeHandle m_node_handle;
+    ros::Subscriber m_imu_subscriber;
+    ros::Publisher m_speed_publisher;
+
+    double xAcc;
+    double yAcc;
+    double zAcc;
+
+    double initX;
+    double initY;
+    double initZ;
+    bool initSet;
+
+    ros::Time lastValueTime;
+
+    void scanCallback(const sensor_msgs::Imu::ConstPtr& imu);
+};

--- a/ros_ws/src/imu_velocity/launch/car_imu_velocity.launch
+++ b/ros_ws/src/imu_velocity/launch/car_imu_velocity.launch
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+<!-- 
+Launches all necessary nodes that transform various frames
+-->
+
+    <node
+      respawn="true"
+      pkg="imu_velocity"
+      type="imu_accumulator"
+      name="imu_accumulator"
+      output="screen" >
+    </node>
+	
+</launch>

--- a/ros_ws/src/imu_velocity/package.xml
+++ b/ros_ws/src/imu_velocity/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package format="2">
+  <name>imu_velocity</name>
+  <version>0.0.0</version>
+  <description>The imu_velocity package</description>
+
+    <!-- Maintainer -->
+  <maintainer email="f110@ls12.cs.uni-dortmund.de">PG F1/10</maintainer>
+
+  <!-- License -->
+  <license>MIT</license>
+  <license>GPLv3</license>
+
+    <!-- Dependencies -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_export_depend>sensor_msgs</build_export_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <depend>geometry_msgs</depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/ros_ws/src/imu_velocity/src/imu_accumulator.cpp
+++ b/ros_ws/src/imu_velocity/src/imu_accumulator.cpp
@@ -1,0 +1,39 @@
+#include "imu_accumulator.h"
+#include <ros/ros.h>
+#include <sensor_msgs/Imu.h>
+#include <geometry_msgs/Vector3.h>
+
+ImuAccumulator::ImuAccumulator()
+{
+    m_imu_subscriber = m_node_handle.subscribe<sensor_msgs::Imu>(TOPIC_IMU_DATA, 100,
+                                                                             &ImuAccumulator::scanCallback, this);
+    m_speed_publisher = m_node_handle.advertise<geometry_msgs::Vector3>(TOPIC_VELOCITY_OUTPUT, 100, false);
+}
+
+void ImuAccumulator::scanCallback(const sensor_msgs::Imu::ConstPtr& imuData)
+{
+    if(!initSet) {
+        initX = imuData->linear_acceleration.x;
+        initY = imuData->linear_acceleration.y;
+        initZ = imuData->linear_acceleration.z;
+        initSet = true;
+        lastValueTime = ros::Time::now();
+        return;
+    }
+    
+    geometry_msgs::Vector3 velocity;
+
+    ros::Duration timeDiff = ros::Time::now() - lastValueTime;
+
+    xAcc += (imuData->linear_acceleration.x - initX) * timeDiff.toSec();
+    yAcc += (imuData->linear_acceleration.y - initY) * timeDiff.toSec();
+    zAcc += (imuData->linear_acceleration.z - initZ) * timeDiff.toSec();
+    
+    velocity.x = xAcc;
+    velocity.y = yAcc;
+    velocity.z = zAcc;
+
+    lastValueTime = ros::Time::now();
+
+    m_speed_publisher.publish(velocity);
+}

--- a/ros_ws/src/imu_velocity/src/imu_accumulator.cpp
+++ b/ros_ws/src/imu_velocity/src/imu_accumulator.cpp
@@ -1,18 +1,19 @@
 #include "imu_accumulator.h"
+#include <geometry_msgs/Vector3.h>
 #include <ros/ros.h>
 #include <sensor_msgs/Imu.h>
-#include <geometry_msgs/Vector3.h>
 
 ImuAccumulator::ImuAccumulator()
 {
-    m_imu_subscriber = m_node_handle.subscribe<sensor_msgs::Imu>(TOPIC_IMU_DATA, 100,
-                                                                             &ImuAccumulator::scanCallback, this);
+    m_imu_subscriber =
+        m_node_handle.subscribe<sensor_msgs::Imu>(TOPIC_IMU_DATA, 100, &ImuAccumulator::scanCallback, this);
     m_speed_publisher = m_node_handle.advertise<geometry_msgs::Vector3>(TOPIC_VELOCITY_OUTPUT, 100, false);
 }
 
 void ImuAccumulator::scanCallback(const sensor_msgs::Imu::ConstPtr& imuData)
 {
-    if(!initSet) {
+    if (!initSet)
+    {
         initX = imuData->linear_acceleration.x;
         initY = imuData->linear_acceleration.y;
         initZ = imuData->linear_acceleration.z;
@@ -20,7 +21,7 @@ void ImuAccumulator::scanCallback(const sensor_msgs::Imu::ConstPtr& imuData)
         lastValueTime = ros::Time::now();
         return;
     }
-    
+
     geometry_msgs::Vector3 velocity;
 
     ros::Duration timeDiff = ros::Time::now() - lastValueTime;
@@ -28,7 +29,7 @@ void ImuAccumulator::scanCallback(const sensor_msgs::Imu::ConstPtr& imuData)
     xAcc += (imuData->linear_acceleration.x - initX) * timeDiff.toSec();
     yAcc += (imuData->linear_acceleration.y - initY) * timeDiff.toSec();
     zAcc += (imuData->linear_acceleration.z - initZ) * timeDiff.toSec();
-    
+
     velocity.x = xAcc;
     velocity.y = yAcc;
     velocity.z = zAcc;

--- a/ros_ws/src/imu_velocity/src/main.cpp
+++ b/ros_ws/src/imu_velocity/src/main.cpp
@@ -1,0 +1,17 @@
+#include "imu_accumulator.h"
+
+/**
+ * @brief Starts the imu accumulator
+ *
+ * @param argc number of input arguments
+ * @param argv input arguments
+ * @return int exit code
+ */
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "imu_accumulator");
+    ImuAccumulator imu_accumulator;
+    ros::spin();
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This is obviously terrible. Bias error will accumulate over time, leading to a huge error after just some time.
In the future, we should combine this value and the car odometry via a Kalman filter, but right now it has to do. Gazebo simulation seems to have especially high noise values, we might get lucky on the real car.