### PR TITLE
Fix old certificates on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   include:
     - # build project
-      if: type = pull_request OR branch = development
+      #if: type = pull_request OR branch = development
 
       addons:
         apt:
@@ -24,6 +24,7 @@ jobs:
             - libsdl2-dev
             - clang-format-3.9
             - libyaml-cpp0.5v5
+            - ca-certificates
 
       cache:
           apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   include:
     - # build project
-      #if: type = pull_request OR branch = development
+      if: type = pull_request OR branch = development
 
       addons:
         apt:


### PR DESCRIPTION
Not updating the certificates lead to a submodule not being pulled successfully. We now update the certificates before cloning and successfully build again.